### PR TITLE
Improve feedback when API key missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Chat with the agent to:
    ```python
    ANTHROPIC_API_KEY = "your-api-key-here"
    ```
+   The application will exit with a clear message if this key is not set.
 
 3. Run the application:
    ```bash

--- a/simple_truss_agent.py
+++ b/simple_truss_agent.py
@@ -4,11 +4,16 @@ import os
 from PIL import Image
 import tools
 from tools import client
-from config import MODEL_NAME
+from config import MODEL_NAME, ANTHROPIC_API_KEY
 from colorama import init, Fore, Style
 
 # Initialize colorama for Windows compatibility
 init()
+
+# Ensure a valid API key is configured before making any requests
+if not ANTHROPIC_API_KEY or ANTHROPIC_API_KEY == "your-api-key-here":
+    print("Error: Please set your Anthropic API key in config.py before running the application.")
+    raise SystemExit(1)
 
 class TrussState:
     """Manages the state and formatting of truss data"""


### PR DESCRIPTION
## Summary
- handle missing Anthropic key early in `simple_truss_agent.py`
- document the new behaviour in README

## Testing
- `python -m py_compile simple_truss_agent.py tools.py config.py`
- `python simple_truss_agent.py` (fails with helpful message)